### PR TITLE
merge_repeated should be set False

### DIFF
--- a/CRNN/crnn.py
+++ b/CRNN/crnn.py
@@ -164,7 +164,7 @@ class CRNN(object):
         optimizer = tf.train.AdamOptimizer(learning_rate=0.0001).minimize(cost)
 
         # The decoded answer
-        decoded, log_prob = tf.nn.ctc_beam_search_decoder(logits, seq_len)
+        decoded, log_prob = tf.nn.ctc_beam_search_decoder(logits, seq_len, merge_repeated=False)
 
         dense_decoded = tf.sparse_tensor_to_dense(decoded[0], default_value=-1)
 


### PR DESCRIPTION
Hi, recently I studies the source code of TensorFlow, mainly CTC decoder, I found that the argument merge_repeated should be set False.
According to https://www.tensorflow.org/api_docs/python/tf/nn/ctc_beam_search_decoder, I think the top path is the sequence we needed, not the one after merge.
And the source code is LabelSeq() in https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/util/ctc/ctc_beam_entry.h:
      if (!merge_repeated || c->label != prev_label) {
        labels.push_back(c->label);
      }
This labels should be sequence after many-to-one map, otherwise the blank should be judged.
I have tested this in my own project, there is a surprising increase of accuracy after I change the merge_repeated from True to False, and I watched the sequence generated by beam search, all the sequences(merge_repeated=True or False) don't contain the blank.
Sorry I haven't test this property in this project, the environment is unique. Besides, I have fount the same setting in https://github.com/synckey/tensorflow_lstm_ctc_ocr/blob/master/lstm_and_ctc_ocr_train.py.